### PR TITLE
fixed import + applicationInfo retrieval

### DIFF
--- a/src/android/WebViewDebug.java
+++ b/src/android/WebViewDebug.java
@@ -4,6 +4,7 @@ import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CordovaPlugin;
 
+import android.content.pm.ApplicationInfo;
 import android.os.Build;
 import android.webkit.WebView;
 
@@ -30,7 +31,7 @@ public class WebViewDebug extends CordovaPlugin
         
         Log.v(TAG, "Checking SDK Version: " + Build.VERSION.SDK_INT);
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        	if ( 0 != ( getApplicationInfo().flags &= ApplicationInfo.FLAG_DEBUGGABLE ) ) {
+        	if ( 0 != (cordova.getActivity().getApplication().getApplicationInfo().flags &= ApplicationInfo.FLAG_DEBUGGABLE ) ) {
         		Log.v(TAG, "Attempting to enable WebView.setWebContentsDebuggingEnabled");
         		
         		WebView.setWebContentsDebuggingEnabled(true);


### PR DESCRIPTION
Hi,
I tried your plugin with Android 4.4.2 using Cordova 3.3 and compiling android failed. It looks like there was a missing import. The retrieval of the ApplicationInfo seemed to have changed and a direct call to getApplicationInfo() is not possible ; i don't know if it is from a change in Cordova 3.3. May be we should adapt this behavior so that the plugin will be compatible with both Cordova 3.2 and Cordova 3.3 but I have no idea on how to achieve that (I am fairly new to Cordova 3).
